### PR TITLE
Fix newlines around timestamp header

### DIFF
--- a/src/journal_io/mod.rs
+++ b/src/journal_io/mod.rs
@@ -723,9 +723,11 @@ pub(crate) fn append_timestamp_header(
         );
         append_to_file(&mut file, &entry)?;
     } else {
-        // File has content: only add time header
+        // File has content: ensure a blank line before the time header
+        let prefix = if content.ends_with('\n') { "\n" } else { "\n\n" };
         let entry = format!(
-            "## {}\n\n",
+            "{}## {}\n\n",
+            prefix,
             reference_datetime.format(constants::JOURNAL_HEADER_TIME_FORMAT)
         );
         append_to_file(&mut file, &entry)?;
@@ -985,6 +987,11 @@ mod tests {
             reference_datetime.format(constants::JOURNAL_HEADER_TIME_FORMAT)
         );
         assert!(content.contains(&time_header));
+
+        // Verify the timestamp header is separated by a blank line
+        let separator = format!("Existing journal content\n\n## {}",
+            reference_datetime.format(constants::JOURNAL_HEADER_TIME_FORMAT));
+        assert!(content.contains(&separator));
 
         // The original date header should still be there (only once)
         let date_headers: Vec<&str> = content.matches("# May 29, 2025: Thursday").collect();

--- a/src/journal_io/mod.rs
+++ b/src/journal_io/mod.rs
@@ -724,7 +724,11 @@ pub(crate) fn append_timestamp_header(
         append_to_file(&mut file, &entry)?;
     } else {
         // File has content: ensure a blank line before the time header
-        let prefix = if content.ends_with('\n') { "\n" } else { "\n\n" };
+        let prefix = if content.ends_with('\n') {
+            "\n"
+        } else {
+            "\n\n"
+        };
         let entry = format!(
             "{}## {}\n\n",
             prefix,

--- a/src/journal_io/mod.rs
+++ b/src/journal_io/mod.rs
@@ -993,8 +993,10 @@ mod tests {
         assert!(content.contains(&time_header));
 
         // Verify the timestamp header is separated by a blank line
-        let separator = format!("Existing journal content\n\n## {}",
-            reference_datetime.format(constants::JOURNAL_HEADER_TIME_FORMAT));
+        let separator = format!(
+            "Existing journal content\n\n## {}\n\n",
+            reference_datetime.format(constants::JOURNAL_HEADER_TIME_FORMAT)
+        );
         assert!(content.contains(&separator));
 
         // The original date header should still be there (only once)


### PR DESCRIPTION
## Summary
- add logic to ensure a blank line precedes appended timestamps
- update unit test to check for preceding blank line

## Testing
- `cargo test --quiet` *(fails: failed to download from crates.io)*

------
https://chatgpt.com/codex/tasks/task_e_6839d193588483229bf233f5323dd79b