### PR TITLE
🔧 `claude-code-review` workflow failed because Depen

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,11 +12,8 @@ on:
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    # Skip for Dependabot PRs - they don't have access to secrets
+    if: github.actor != 'dependabot[bot]'
 
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## 🔧 Automated CI Fix

> *"Everything's shiny, Captain. Not to fret."*

### What broke
The `claude-code-review` workflow failed because Dependabot PRs cannot access repository secrets (`CLAUDE_CODE_OAUTH_TOKEN`), which is required by the `anthropics/claude-code-action@v1`.

### What I fixed
Added a condition to skip the claude-code-review job when the PR is from Dependabot:
```yaml
if: github.actor != 'dependabot[bot]'
```

This is the right fix because:
1. Dependabot PRs are just dependency bumps - they don't really need a Claude code review
2. Dependabot can't access secrets anyway (GitHub security feature)
3. The actual code change (clap version bump) is fine and doesn't need fixing

### The details
<details>
<summary>Full diagnosis</summary>

Done!

### Root Cause
The `claude-code-review` workflow failed because Dependabot PRs cannot access repository secrets (`CLAUDE_CODE_OAUTH_TOKEN`), which is required by the `anthropics/claude-code-action@v1`.

### Fix
Added a condition to skip the claude-code-review job when the PR is from Dependabot:
```yaml
if: github.actor != 'dependabot[bot]'
```

This is the right fix because:
1. Dependabot PRs are just dependency bumps - they don't really need a Claude code review
2. Dependabot can't access secrets anyway (GitHub security feature)
3. The actual code change (clap version bump) is fine and doesn't need fixing
</details>

---
*🤖 Generated by [kaylee](https://github.com/misty-step/kaylee) — your friendly neighborhood CI mechanic*
*Fixing PR #57 in phrazzld/ponder*
