### PR TITLE
🛠️ `claude-code-review

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,11 +12,8 @@ on:
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    # Skip for Dependabot PRs since they don't have access to secrets
+    if: github.event.pull_request.user.login != 'dependabot[bot]'
 
     runs-on: ubuntu-latest
     permissions:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2564,18 +2564,28 @@ checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2584,14 +2594,15 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.140"
+version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
 dependencies = [
  "itoa",
  "memchr",
  "ryu",
  "serde",
+ "serde_core",
 ]
 
 [[package]]


### PR DESCRIPTION
## 🔧 Automated CI Fix

> *"Everything's shiny, Captain. Not to fret."*

### What broke
The `claude-code-review.yml` workflow fails on Dependabot PRs because Dependabot doesn't have access to repository secrets (`CLAUDE_CODE_OAUTH_TOKEN`) for security reasons.

### What I fixed
Edited `.github/workflows/claude-code-review.yml` to add a condition that skips the Claude code review job for PRs created by `dependabot[bot]`:

```yaml
if: github.event.pull_request.user.login != 'dependabot[bot]'
```

This is the right fix - the actual serde_json dependency bump in the PR is totally fine and not causing any issues. The problem was the CI workflow trying to run a Claude review on a Dependabot PR without access to the required OAuth token.

### The details
<details>
<summary>Full diagnosis</summary>

Done!

### Root Cause
The `claude-code-review.yml` workflow fails on Dependabot PRs because Dependabot doesn't have access to repository secrets (`CLAUDE_CODE_OAUTH_TOKEN`) for security reasons.

### Fix
Edited `.github/workflows/claude-code-review.yml` to add a condition that skips the Claude code review job for PRs created by `dependabot[bot]`:

```yaml
if: github.event.pull_request.user.login != 'dependabot[bot]'
```

This is the right fix - the actual serde_json dependency bump in the PR is totally fine and not causing any issues. The problem was the CI workflow trying to run a Claude review on a Dependabot PR without access to the required OAuth token.
</details>

---
*🤖 Generated by [kaylee](https://github.com/misty-step/kaylee) — your friendly neighborhood CI mechanic*
*Fixing PR #53 in phrazzld/ponder*
